### PR TITLE
Added import with custom alias

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,13 @@ codimd import test.md                   # takes a markdown file
 qhmNmwmxSmK1H2oJmkKBQQ                  # returns <note_id> on success
 ```
 
+### Create/import a new note with a given alias
+This requires that the server has the FreeURL mode enabled.
+```bash
+codimd import-as note-alias test.md     # takes a markdown file
+note-alias                              # returns the alias on success
+```
+
 ### Publish an existing note
 
 ```bash
@@ -93,6 +100,7 @@ These server endpoints are used by this project and can be unstable and undocume
  - `https://<codimd_server>/me`
  - `https://<codimd_server>/history`  (requires auth)
  - `https://<codimd_server>/new`
+ - `https://<codimd_server>/new/<alias>`
  - `https://<codimd_server>/<note_id>/publish`
  - `https://<codimd_server>/<note_id>/download`
  - `https://<codimd_server>/<note_id>/pdf`

--- a/bin/codimd
+++ b/bin/codimd
@@ -26,6 +26,9 @@ Options:
     $ $codi_cli import /path/to/your/content.md
     qhmNmwmxSmK1H2oJmkKBQQ       # returns note id on success
 
+    $ $codi_cli import-as note-alias /path/to/your/content.md
+    note-alias                   # returns note alias on success
+
     $ $codi_cli publish qhmNmwmxSmK1H2oJmkKBQQ
     /s/S1ok9no3f                 # returns published note url
 
@@ -57,6 +60,10 @@ function publish_note() {
 
 function import_note() {
     curl -q -b "$CODIMD_COOKIES_FILE" -XPOST -H 'Content-Type: text/markdown' --data-binary "@$1" "$CODIMD_SERVER/new" 2>/dev/null | perl -pe 's/Found. Redirecting to \/(.+?)$/$1\n/gs'
+}
+
+function import_note_alias() {
+    curl -q -b "$CODIMD_COOKIES_FILE" -XPOST -H 'Content-Type: text/markdown' --data-binary "@$2" "$CODIMD_SERVER/new/$1" 2>/dev/null | perl -pe 's/Found. Redirecting to \/(.+?)$/$1\n/gs'
 }
 
 function export_note() {
@@ -219,6 +226,9 @@ logout)
     ;;
 import)
     import_note "$2"
+    ;;
+import-as)
+    import_note_alias "$2" "$3"
     ;;
 export)
     export_note "$2" "$3" "$4"


### PR DESCRIPTION
With the next release of CodiMD there will be the endpoint `/new/<custom-alias>` which imports the note with the given alias name if FreeURL mode is enabled. This PR adds a new command `import-as` that allows to import a note with a given alias.
This feature can be used for example for a better etherpad migration.